### PR TITLE
FE-3: Health indicator calls GET /health

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8080

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,2 @@
+export const API_BASE =
+  import.meta.env.VITE_API_BASE || "http://localhost:8080";


### PR DESCRIPTION
wired up the health indicator to call GET /health. shows green/UP when backend is running and red/DOWN when its not. also added config.js so the api url is in one place.

Closes #12