### PR TITLE
Add CORS headers to backend middleware

### DIFF
--- a/backend/internal/middleware/middleware.go
+++ b/backend/internal/middleware/middleware.go
@@ -48,6 +48,15 @@ func WithRequestIDAndLogging(next http.Handler) http.Handler {
 
 		// Add request id to every response
 		w.Header().Set("X-Request-Id", reqID)
+		// CORS
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rec, r)


### PR DESCRIPTION
## Summary
- Adds CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`) to the existing `WithRequestIDAndLogging` middleware
- Handles preflight `OPTIONS` requests with an early `200 OK` return
- Unblocks the frontend on `localhost:5173` from calling backend endpoints (`/health`, `/api/v1/status`, `/api/v1/request`) on `localhost:8080`

Fixes #22

## Test plan
- [ ] Verify frontend dashboard can reach `/health` endpoint without CORS errors
- [ ] Verify frontend can poll `/api/v1/status` successfully
- [ ] Verify frontend can POST to `/api/v1/request` successfully
- [ ] Confirm preflight OPTIONS requests return 200