### PR TITLE
Add Services Status panel with circuit breaker badges #F1

### DIFF
--- a/frontend/cypress/e2e/dashboard.cy.js
+++ b/frontend/cypress/e2e/dashboard.cy.js
@@ -40,6 +40,11 @@ describe("EdgeForge Dashboard", () => {
     cy.get("html").should("have.attr", "data-theme", "dark");
   });
 
+  it("renders the Services Status panel with at least one instance row", () => {
+    cy.contains("Services Status").should("be.visible");
+    cy.get('[data-instance-name]').should("have.length.gte", 1);
+  });
+
   it("exposes the alert threshold control in settings", () => {
     cy.window().then((win) => win.localStorage.clear());
     cy.reload();

--- a/frontend/cypress/e2e/dashboard.cy.js
+++ b/frontend/cypress/e2e/dashboard.cy.js
@@ -39,4 +39,12 @@ describe("EdgeForge Dashboard", () => {
     cy.reload();
     cy.get("html").should("have.attr", "data-theme", "dark");
   });
+
+  it("exposes the alert threshold control in settings", () => {
+    cy.window().then((win) => win.localStorage.clear());
+    cy.reload();
+    cy.contains("Show Settings").click();
+    cy.get('input[aria-label="Enable error rate alerts"]').should("exist").and("be.checked");
+    cy.get('input[aria-label="Error rate alert threshold"]').should("have.value", "10");
+  });
 });

--- a/frontend/cypress/e2e/dashboard.cy.js
+++ b/frontend/cypress/e2e/dashboard.cy.js
@@ -29,4 +29,14 @@ describe("EdgeForge Dashboard", () => {
     cy.contains("Errors / sec").should("be.visible");
     cy.contains("Rate Limited / sec").should("be.visible");
   });
+
+  it("toggles dark mode and persists across reload", () => {
+    cy.window().then((win) => win.localStorage.clear());
+    cy.reload();
+    cy.contains("Show Settings").click();
+    cy.get('select[aria-label="Theme"]').select("dark");
+    cy.get("html").should("have.attr", "data-theme", "dark");
+    cy.reload();
+    cy.get("html").should("have.attr", "data-theme", "dark");
+  });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,16 +2,55 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #213547;
-  background-color: #f9fafb;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --bg-page: #f9fafb;
+  --bg-card: #ffffff;
+  --bg-header-row: #f9fafb;
+  --bg-muted: #f3f4f6;
+  --bg-code: #111827;
+  --text-primary: #213547;
+  --text-secondary: #6b7280;
+  --text-strong: #111827;
+  --text-muted: #9ca3af;
+  --text-on-code: #e5e7eb;
+  --border: #e5e7eb;
+  --border-soft: #f3f4f6;
+  --modal-overlay: rgba(0, 0, 0, 0.5);
+  --shadow-card: 0 1px 4px rgba(0, 0, 0, 0.06);
+  --shadow-modal: 0 10px 30px rgba(0, 0, 0, 0.2);
+
+  color: var(--text-primary);
+  background-color: var(--bg-page);
+}
+
+[data-theme="dark"] {
+  --bg-page: #0f172a;
+  --bg-card: #1e293b;
+  --bg-header-row: #0f172a;
+  --bg-muted: #334155;
+  --bg-code: #020617;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-strong: #f1f5f9;
+  --text-muted: #64748b;
+  --text-on-code: #cbd5e1;
+  --border: #334155;
+  --border-soft: #1e293b;
+  --modal-overlay: rgba(0, 0, 0, 0.7);
+  --shadow-card: 0 1px 4px rgba(0, 0, 0, 0.4);
+  --shadow-modal: 0 10px 30px rgba(0, 0, 0, 0.6);
+
+  color-scheme: dark;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background: var(--bg-page);
+  color: var(--text-primary);
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -16,6 +16,7 @@ import {
   loadSettings,
   saveSettings,
   applyTheme,
+  findAlertingServices,
 } from "../utils/metrics";
 
 function Card({ title, children }) {
@@ -177,6 +178,7 @@ export default function Dashboard() {
     );
   }, [status, settings?.chartWindow]);
 
+  const [dismissedAlerts, setDismissedAlerts] = useState(() => new Set());
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState("");
   const [lastResponse, setLastResponse] = useState(null);
@@ -355,6 +357,67 @@ export default function Dashboard() {
   return (
     <div style={{ minHeight: "100vh", background: "var(--bg-page)" }}>
       <div style={{ maxWidth: 1100, margin: "0 auto", padding: 24 }}>
+        {(() => {
+          const alerts = findAlertingServices(requestLog, settings).filter(
+            (a) => !dismissedAlerts.has(a.service)
+          );
+          if (alerts.length === 0) return null;
+          return (
+            <div
+              role="alert"
+              aria-label="Error rate alert"
+              style={{
+                marginBottom: 14,
+                padding: "12px 16px",
+                borderRadius: 10,
+                border: "1px solid #fecaca",
+                background: "#fef2f2",
+                color: "#991b1b",
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <div style={{ fontSize: 13, lineHeight: 1.45 }}>
+                <strong style={{ fontWeight: 700 }}>
+                  Error rate above {settings.errorRateAlertPct}%
+                </strong>
+                <ul style={{ margin: "4px 0 0", paddingLeft: 18 }}>
+                  {alerts.map((a) => (
+                    <li key={a.service}>
+                      <code style={{ fontSize: 12 }}>{a.service}</code> —{" "}
+                      {a.errorRatePct}% errors over last {a.total} requests
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <button
+                aria-label="Dismiss alert"
+                onClick={() =>
+                  setDismissedAlerts((prev) => {
+                    const next = new Set(prev);
+                    alerts.forEach((a) => next.add(a.service));
+                    return next;
+                  })
+                }
+                style={{
+                  border: "1px solid #fecaca",
+                  background: "transparent",
+                  color: "#991b1b",
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  flexShrink: 0,
+                }}
+              >
+                Dismiss
+              </button>
+            </div>
+          );
+        })()}
         <header style={{ marginBottom: 16 }}>
           <h1 style={{ margin: 0, fontSize: 28 }}>EdgeForge Dashboard</h1>
           <p style={{ marginTop: 6, color: "var(--text-secondary)" }}>
@@ -434,6 +497,37 @@ export default function Dashboard() {
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
                   </select>
+                </label>
+                <label style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                  <input
+                    type="checkbox"
+                    aria-label="Enable error rate alerts"
+                    checked={!!settings.enableAlerts}
+                    onChange={(e) => {
+                      updateSetting("enableAlerts", e.target.checked);
+                      if (e.target.checked) setDismissedAlerts(new Set());
+                    }}
+                  />
+                  Enable alerts
+                </label>
+                <label>
+                  Alert threshold:{" "}
+                  <input
+                    type="number"
+                    aria-label="Error rate alert threshold"
+                    min={1}
+                    max={100}
+                    value={settings.errorRateAlertPct}
+                    onChange={(e) => {
+                      const n = Number(e.target.value);
+                      if (Number.isFinite(n) && n >= 1 && n <= 100) {
+                        updateSetting("errorRateAlertPct", n);
+                        setDismissedAlerts(new Set());
+                      }
+                    }}
+                    style={{ width: 60, padding: "4px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg-card)", color: "var(--text-primary)" }}
+                  />
+                  %
                 </label>
               </div>
             )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -9,23 +9,30 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { API_BASE } from "../config";
-import { aggregateByService, filterRequestLog, toCsv, loadSettings, saveSettings } from "../utils/metrics";
+import {
+  aggregateByService,
+  filterRequestLog,
+  toCsv,
+  loadSettings,
+  saveSettings,
+  applyTheme,
+} from "../utils/metrics";
 
 function Card({ title, children }) {
   return (
     <div
       style={{
-        border: "1px solid #e5e7eb",
+        border: "1px solid var(--border)",
         borderRadius: 12,
         padding: 16,
-        background: "white",
-        boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+        background: "var(--bg-card)",
+        boxShadow: "var(--shadow-card)",
       }}
     >
       <div
         style={{
           fontSize: 14,
-          color: "#374151",
+          color: "var(--text-strong)",
           marginBottom: 10,
           fontWeight: 600,
         }}
@@ -46,6 +53,17 @@ export default function Dashboard() {
     setSettings(next);
     saveSettings(next);
   }
+
+  useEffect(() => {
+    applyTheme(settings?.theme);
+    if (settings?.theme !== "system" || typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener?.("change", handler);
+    return () => mq.removeEventListener?.("change", handler);
+  }, [settings?.theme]);
 
   const [health, setHealth] = useState({
     state: "loading",
@@ -335,11 +353,11 @@ export default function Dashboard() {
   }
 
   return (
-    <div style={{ minHeight: "100vh", background: "#f9fafb" }}>
+    <div style={{ minHeight: "100vh", background: "var(--bg-page)" }}>
       <div style={{ maxWidth: 1100, margin: "0 auto", padding: 24 }}>
         <header style={{ marginBottom: 16 }}>
           <h1 style={{ margin: 0, fontSize: 28 }}>EdgeForge Dashboard</h1>
-          <p style={{ marginTop: 6, color: "#6b7280" }}>
+          <p style={{ marginTop: 6, color: "var(--text-secondary)" }}>
             Sprint 2: Traffic simulation, request logging, and real-time
             charts.
           </p>
@@ -351,13 +369,13 @@ export default function Dashboard() {
             <button
               onClick={() => setSettingsOpen(!settingsOpen)}
               style={{
-                border: "1px solid #e5e7eb",
-                background: "white",
+                border: "1px solid var(--border)",
+                background: "var(--bg-card)",
                 padding: "6px 12px",
                 borderRadius: 8,
                 cursor: "pointer",
                 fontSize: 12,
-                color: "#374151",
+                color: "var(--text-strong)",
                 marginBottom: settingsOpen ? 12 : 0,
               }}
             >
@@ -371,7 +389,7 @@ export default function Dashboard() {
                     aria-label="Poll interval"
                     value={settings.pollInterval}
                     onChange={(e) => updateSetting("pollInterval", Number(e.target.value))}
-                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid #e5e7eb" }}
+                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg-card)", color: "var(--text-primary)" }}
                   >
                     <option value={1000}>1s</option>
                     <option value={1500}>1.5s</option>
@@ -384,7 +402,7 @@ export default function Dashboard() {
                     aria-label="Max log entries"
                     value={settings.maxLogSize}
                     onChange={(e) => updateSetting("maxLogSize", Number(e.target.value))}
-                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid #e5e7eb" }}
+                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg-card)", color: "var(--text-primary)" }}
                   >
                     <option value={50}>50</option>
                     <option value={100}>100</option>
@@ -397,11 +415,24 @@ export default function Dashboard() {
                     aria-label="Chart history window"
                     value={settings.chartWindow}
                     onChange={(e) => updateSetting("chartWindow", Number(e.target.value))}
-                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid #e5e7eb" }}
+                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg-card)", color: "var(--text-primary)" }}
                   >
                     <option value={15}>15</option>
                     <option value={30}>30</option>
                     <option value={60}>60</option>
+                  </select>
+                </label>
+                <label>
+                  Theme:{" "}
+                  <select
+                    aria-label="Theme"
+                    value={settings.theme}
+                    onChange={(e) => updateSetting("theme", e.target.value)}
+                    style={{ padding: "4px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg-card)", color: "var(--text-primary)" }}
+                  >
+                    <option value="system">System</option>
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
                   </select>
                 </label>
               </div>
@@ -429,7 +460,7 @@ export default function Dashboard() {
               <span style={{ fontWeight: 700 }}>{health.message}</span>
             </div>
             <div
-              style={{ marginTop: 10, color: "#6b7280", fontSize: 13 }}
+              style={{ marginTop: 10, color: "var(--text-secondary)", fontSize: 13 }}
             >
               {API_BASE} <span style={{ marginLeft: 8 }}>|</span>{" "}
               <code>GET /health</code>
@@ -463,7 +494,7 @@ export default function Dashboard() {
 
           {/* Send Test Request */}
           <Card title="Send Test Request">
-            <p style={{ marginTop: 0, color: "#6b7280" }}>
+            <p style={{ marginTop: 0, color: "var(--text-secondary)" }}>
               Sends a request to the gateway to simulate routing. Endpoint:{" "}
               <code>POST /api/v1/request</code>
             </p>
@@ -521,7 +552,7 @@ export default function Dashboard() {
                 style={{
                   fontSize: 13,
                   fontWeight: 600,
-                  color: "#374151",
+                  color: "var(--text-strong)",
                   marginBottom: 6,
                 }}
               >
@@ -532,8 +563,8 @@ export default function Dashboard() {
                   margin: 0,
                   padding: 12,
                   borderRadius: 10,
-                  background: "#111827",
-                  color: "#e5e7eb",
+                  background: "var(--bg-code)",
+                  color: "var(--text-on-code)",
                   overflowX: "auto",
                   minHeight: 70,
                 }}
@@ -547,7 +578,7 @@ export default function Dashboard() {
 
           {/* Traffic Simulation */}
           <Card title="Traffic Simulation">
-            <p style={{ marginTop: 0, color: "#6b7280" }}>
+            <p style={{ marginTop: 0, color: "var(--text-secondary)" }}>
               Send bulk requests to simulate different traffic patterns.
             </p>
 
@@ -590,8 +621,8 @@ export default function Dashboard() {
                   gap: 10,
                 }}
               >
-                <div style={{ padding: 10, background: "#f3f4f6", borderRadius: 8, textAlign: "center" }}>
-                  <div style={{ fontSize: 12, color: "#6b7280" }}>Total</div>
+                <div style={{ padding: 10, background: "var(--bg-muted)", borderRadius: 8, textAlign: "center" }}>
+                  <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>Total</div>
                   <div style={{ fontSize: 18, fontWeight: 700 }}>{simResults.total}</div>
                 </div>
                 <div style={{ padding: 10, background: "#ecfdf5", borderRadius: 8, textAlign: "center" }}>
@@ -631,7 +662,7 @@ export default function Dashboard() {
                       alignItems: "center",
                     }}
                   >
-                    <label style={{ fontSize: 12, color: "#6b7280" }}>
+                    <label style={{ fontSize: 12, color: "var(--text-secondary)" }}>
                       Filter by service:{" "}
                       <select
                         aria-label="Filter by service"
@@ -643,7 +674,7 @@ export default function Dashboard() {
                           marginLeft: 4,
                           padding: "4px 8px",
                           borderRadius: 6,
-                          border: "1px solid #e5e7eb",
+                          border: "1px solid var(--border)",
                           fontSize: 12,
                         }}
                       >
@@ -655,7 +686,7 @@ export default function Dashboard() {
                         ))}
                       </select>
                     </label>
-                    <label style={{ fontSize: 12, color: "#6b7280" }}>
+                    <label style={{ fontSize: 12, color: "var(--text-secondary)" }}>
                       Status:{" "}
                       <select
                         aria-label="Filter by status"
@@ -667,7 +698,7 @@ export default function Dashboard() {
                           marginLeft: 4,
                           padding: "4px 8px",
                           borderRadius: 6,
-                          border: "1px solid #e5e7eb",
+                          border: "1px solid var(--border)",
                           fontSize: 12,
                         }}
                       >
@@ -688,13 +719,13 @@ export default function Dashboard() {
                       style={{
                         padding: "4px 8px",
                         borderRadius: 6,
-                        border: "1px solid #e5e7eb",
+                        border: "1px solid var(--border)",
                         fontSize: 12,
                         flex: "1 1 160px",
                         minWidth: 120,
                       }}
                     />
-                    <span style={{ fontSize: 12, color: "#6b7280" }}>
+                    <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
                       Showing {visibleLog.length} of {requestLog.length}
                     </span>
                   </div>
@@ -703,7 +734,7 @@ export default function Dashboard() {
                 maxHeight: 300,
                 overflowY: "auto",
                 borderRadius: 8,
-                border: "1px solid #e5e7eb",
+                border: "1px solid var(--border)",
               }}
             >
               <table
@@ -716,16 +747,16 @@ export default function Dashboard() {
                 <thead>
                   <tr
                     style={{
-                      background: "#f9fafb",
+                      background: "var(--bg-header-row)",
                       position: "sticky",
                       top: 0,
                     }}
                   >
-                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>Time</th>
-                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>Request ID</th>
-                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>Routed To</th>
-                    <th style={{ padding: "8px 10px", textAlign: "center", borderBottom: "1px solid #e5e7eb" }}>Status</th>
-                    <th style={{ padding: "8px 10px", textAlign: "right", borderBottom: "1px solid #e5e7eb" }}>Latency</th>
+                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid var(--border)" }}>Time</th>
+                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid var(--border)" }}>Request ID</th>
+                    <th style={{ padding: "8px 10px", textAlign: "left", borderBottom: "1px solid var(--border)" }}>Routed To</th>
+                    <th style={{ padding: "8px 10px", textAlign: "center", borderBottom: "1px solid var(--border)" }}>Status</th>
+                    <th style={{ padding: "8px 10px", textAlign: "right", borderBottom: "1px solid var(--border)" }}>Latency</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -736,7 +767,7 @@ export default function Dashboard() {
                         style={{
                           padding: 20,
                           textAlign: "center",
-                          color: "#9ca3af",
+                          color: "var(--text-muted)",
                         }}
                       >
                         {requestLog.length === 0
@@ -749,9 +780,9 @@ export default function Dashboard() {
                       <tr
                         key={i}
                         onClick={() => setSelectedRequest(entry)}
-                        style={{ borderBottom: "1px solid #f3f4f6", cursor: "pointer" }}
+                        style={{ borderBottom: "1px solid var(--border-soft)", cursor: "pointer" }}
                       >
-                        <td style={{ padding: "6px 10px", color: "#6b7280" }}>{entry.time}</td>
+                        <td style={{ padding: "6px 10px", color: "var(--text-secondary)" }}>{entry.time}</td>
                         <td style={{ padding: "6px 10px" }}>
                           <code style={{ fontSize: 12 }}>{entry.id}</code>
                         </td>
@@ -784,7 +815,7 @@ export default function Dashboard() {
                           style={{
                             padding: "6px 10px",
                             textAlign: "right",
-                            color: "#6b7280",
+                            color: "var(--text-secondary)",
                           }}
                         >
                           {entry.latency}ms
@@ -800,13 +831,13 @@ export default function Dashboard() {
                 <button
                   onClick={() => setRequestLog([])}
                   style={{
-                    border: "1px solid #e5e7eb",
-                    background: "white",
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-card)",
                     padding: "6px 12px",
                     borderRadius: 8,
                     cursor: "pointer",
                     fontSize: 12,
-                    color: "#6b7280",
+                    color: "var(--text-secondary)",
                   }}
                 >
                   Clear Log
@@ -825,13 +856,13 @@ export default function Dashboard() {
                 }}
                 disabled={requestLog.length === 0}
                 style={{
-                  border: "1px solid #e5e7eb",
-                  background: requestLog.length === 0 ? "#f3f4f6" : "white",
+                  border: "1px solid var(--border)",
+                  background: requestLog.length === 0 ? "var(--bg-muted)" : "var(--bg-card)",
                   padding: "6px 12px",
                   borderRadius: 8,
                   cursor: requestLog.length === 0 ? "not-allowed" : "pointer",
                   fontSize: 12,
-                  color: "#6b7280",
+                  color: "var(--text-secondary)",
                   opacity: requestLog.length === 0 ? 0.6 : 1,
                 }}
               >
@@ -846,14 +877,14 @@ export default function Dashboard() {
           {/* Per-Service Metrics */}
           <Card title="Per-Service Metrics">
             {requestLog.length === 0 ? (
-              <div style={{ color: "#6b7280", fontSize: 13, padding: "8px 0" }}>
+              <div style={{ color: "var(--text-secondary)", fontSize: 13, padding: "8px 0" }}>
                 Send requests to see per-service breakdown.
               </div>
             ) : (
               <div style={{ overflowX: "auto" }}>
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                   <thead>
-                    <tr style={{ textAlign: "left", color: "#6b7280" }}>
+                    <tr style={{ textAlign: "left", color: "var(--text-secondary)" }}>
                       <th style={{ padding: "6px 8px" }}>Service</th>
                       <th style={{ padding: "6px 8px" }}>Total</th>
                       <th style={{ padding: "6px 8px" }}>Success</th>
@@ -864,7 +895,7 @@ export default function Dashboard() {
                   </thead>
                   <tbody>
                     {aggregateByService(requestLog).map((row) => (
-                      <tr key={row.service} style={{ borderTop: "1px solid #f3f4f6" }}>
+                      <tr key={row.service} style={{ borderTop: "1px solid var(--border-soft)" }}>
                         <td style={{ padding: "8px", fontWeight: 600 }}>{row.service}</td>
                         <td style={{ padding: "8px" }}>{row.total}</td>
                         <td style={{ padding: "8px", color: "#16a34a" }}>{row.success}</td>
@@ -952,7 +983,7 @@ export default function Dashboard() {
           style={{
             position: "fixed",
             inset: 0,
-            background: "rgba(0,0,0,0.5)",
+            background: "var(--modal-overlay)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -963,14 +994,14 @@ export default function Dashboard() {
           <div
             onClick={(e) => e.stopPropagation()}
             style={{
-              background: "white",
+              background: "var(--bg-card)",
               borderRadius: 12,
               padding: 24,
               maxWidth: 600,
               width: "100%",
               maxHeight: "80vh",
               overflowY: "auto",
-              boxShadow: "0 10px 30px rgba(0,0,0,0.2)",
+              boxShadow: "var(--shadow-modal)",
             }}
           >
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
@@ -978,8 +1009,8 @@ export default function Dashboard() {
               <button
                 onClick={() => setSelectedRequest(null)}
                 style={{
-                  border: "1px solid #e5e7eb",
-                  background: "white",
+                  border: "1px solid var(--border)",
+                  background: "var(--bg-card)",
                   padding: "6px 12px",
                   borderRadius: 6,
                   cursor: "pointer",
@@ -1011,14 +1042,14 @@ export default function Dashboard() {
             >
               Copy Request ID
             </button>
-            <div style={{ fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 6 }}>Response</div>
+            <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-strong)", marginBottom: 6 }}>Response</div>
             <pre
               style={{
                 margin: 0,
                 padding: 12,
                 borderRadius: 8,
-                background: "#111827",
-                color: "#e5e7eb",
+                background: "var(--bg-code)",
+                color: "var(--text-on-code)",
                 fontSize: 12,
                 overflowX: "auto",
                 maxHeight: 300,

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -17,6 +17,7 @@ import {
   saveSettings,
   applyTheme,
   findAlertingServices,
+  parseTrace,
 } from "../utils/metrics";
 
 function Card({ title, children }) {
@@ -1136,6 +1137,79 @@ export default function Dashboard() {
             >
               Copy Request ID
             </button>
+            {(() => {
+              const trace = parseTrace(selectedRequest);
+              if (trace.length === 0) return null;
+              return (
+                <div aria-label="Request trace timeline" style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-strong)", marginBottom: 8 }}>
+                    Trace ({trace.length} {trace.length === 1 ? "attempt" : "attempts"})
+                  </div>
+                  <ol style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+                    {trace.map((step, idx) => {
+                      const isSuccess = step.outcome === "success";
+                      const isFail = step.outcome === "fail";
+                      const pillBg = isSuccess ? "#ecfdf5" : isFail ? "#fef2f2" : "#fffbeb";
+                      const pillColor = isSuccess ? "#065f46" : isFail ? "#b91c1c" : "#92400e";
+                      return (
+                        <li
+                          key={idx}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "8px 10px",
+                            border: "1px solid var(--border)",
+                            borderRadius: 6,
+                            fontSize: 12,
+                          }}
+                        >
+                          <span
+                            style={{
+                              width: 22,
+                              height: 22,
+                              borderRadius: 999,
+                              display: "inline-flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              background: "var(--bg-muted)",
+                              color: "var(--text-strong)",
+                              fontWeight: 700,
+                              flexShrink: 0,
+                            }}
+                          >
+                            {step.attempt}
+                          </span>
+                          <code style={{ flex: "0 0 auto" }}>{step.instance}</code>
+                          <span
+                            style={{
+                              padding: "2px 8px",
+                              borderRadius: 6,
+                              fontSize: 11,
+                              fontWeight: 600,
+                              background: pillBg,
+                              color: pillColor,
+                            }}
+                          >
+                            {step.outcome}
+                          </span>
+                          {step.latencyMs !== null && (
+                            <span style={{ color: "var(--text-secondary)" }}>
+                              {step.latencyMs}ms
+                            </span>
+                          )}
+                          {step.error && (
+                            <span style={{ color: "#b91c1c", marginLeft: "auto", fontSize: 11 }}>
+                              {step.error}
+                            </span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ol>
+                </div>
+              );
+            })()}
             <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-strong)", marginBottom: 6 }}>Response</div>
             <pre
               style={{

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -18,6 +18,8 @@ import {
   applyTheme,
   findAlertingServices,
   parseTrace,
+  parseServices,
+  breakerBadge,
 } from "../utils/metrics";
 
 function Card({ title, children }) {
@@ -187,28 +189,32 @@ export default function Dashboard() {
   const [requestLog, setRequestLog] = useState([]);
   const [logFilters, setLogFilters] = useState({ service: "all", status: "all", search: "" });
   const [selectedRequest, setSelectedRequest] = useState(null);
-  const [knownInstances, setKnownInstances] = useState([]);
+  const [services, setServices] = useState([]);
+  const knownInstances = services.flatMap((svc) => svc.instances.map((i) => i.name));
 
   useEffect(() => {
     let cancelled = false;
+    let intervalId = null;
+
     async function fetchServices() {
       try {
         const res = await fetch(`${API_BASE}/api/v1/services`);
         const data = await res.json();
-        if (cancelled || !data || typeof data !== "object") return;
-        const names = Object.values(data).flatMap((svc) =>
-          (svc?.instances || []).map((inst) => inst?.name).filter(Boolean)
-        );
-        setKnownInstances(Array.from(new Set(names)));
+        if (cancelled) return;
+        setServices(parseServices(data));
       } catch {
         /* ignore */
       }
     }
+
     fetchServices();
+    intervalId = setInterval(fetchServices, settings?.pollInterval || 1500);
+
     return () => {
       cancelled = true;
+      if (intervalId) clearInterval(intervalId);
     };
-  }, []);
+  }, [settings?.pollInterval]);
 
   async function sendTestRequest() {
     setSending(true);
@@ -967,6 +973,82 @@ export default function Dashboard() {
                 </>
               );
             })()}
+          </Card>
+
+          {/* Services Status (with circuit breaker state) */}
+          <Card title="Services Status">
+            {services.length === 0 ? (
+              <div style={{ color: "var(--text-secondary)", fontSize: 13, padding: "8px 0" }}>
+                Waiting for backend service registry...
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+                {services.map((svc) => (
+                  <div key={svc.service}>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text-strong)", marginBottom: 6 }}>
+                      {svc.service}{" "}
+                      <span style={{ color: "var(--text-secondary)", fontWeight: 400 }}>
+                        — {svc.requests} request{svc.requests === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    <ul aria-label={`${svc.service} instances`} style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+                      {svc.instances.map((inst) => {
+                        const badge = breakerBadge(inst.breaker);
+                        return (
+                          <li
+                            key={inst.name}
+                            data-instance-name={inst.name}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 10,
+                              padding: "8px 10px",
+                              border: "1px solid var(--border)",
+                              borderRadius: 8,
+                              fontSize: 12,
+                            }}
+                          >
+                            <span
+                              aria-label={inst.healthy ? "healthy" : "unhealthy"}
+                              title={inst.healthy ? "healthy" : "unhealthy"}
+                              style={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: 999,
+                                background: inst.healthy ? "#22c55e" : "#ef4444",
+                                flexShrink: 0,
+                              }}
+                            />
+                            <code style={{ flex: "1 1 auto" }}>{inst.name}</code>
+                            <span
+                              data-testid={`breaker-${inst.name}`}
+                              aria-label={`circuit breaker ${badge.label}`}
+                              style={{
+                                padding: "2px 8px",
+                                borderRadius: 6,
+                                fontSize: 11,
+                                fontWeight: 600,
+                                background: badge.bg,
+                                color: badge.color,
+                                border: `1px solid ${badge.border}`,
+                              }}
+                            >
+                              {badge.label}
+                            </span>
+                            <span style={{ color: "var(--text-secondary)" }}>
+                              active {inst.activeRequests}
+                            </span>
+                            <span style={{ color: "var(--text-secondary)" }}>
+                              fail {inst.failures}
+                            </span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
           </Card>
 
           {/* Per-Service Metrics */}

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -273,6 +273,58 @@ describe("Dashboard", () => {
     expect(screen.getByText(/Error rate above 10%/i)).toBeInTheDocument();
   });
 
+  it("renders the trace timeline in the request detail modal when trace is present", async () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/request")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({
+            requestId: "trace-req-1",
+            routedTo: "orders-service-2",
+            status: "success",
+            trace: [
+              { attempt: 1, instance: "orders-service-1", status: "fail", latencyMs: 120, error: "connection refused" },
+              { attempt: 2, instance: "orders-service-2", status: "success", latencyMs: 30 },
+            ],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    fireEvent.click(screen.getByRole("button", { name: "Send Test Request" }));
+    await waitFor(() => {
+      expect(screen.getAllByText("orders-service-2").length).toBeGreaterThan(0);
+    });
+    const row = screen.getAllByText("orders-service-2").find((el) => el.tagName === "TD");
+    fireEvent.click(row);
+    expect(screen.getByLabelText("Request trace timeline")).toBeInTheDocument();
+    expect(screen.getByText(/Trace \(2 attempts\)/i)).toBeInTheDocument();
+    expect(screen.getByText("connection refused")).toBeInTheDocument();
+  });
+
+  it("does not render the trace section when the response has no trace", async () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/request")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ requestId: "no-trace", routedTo: "orders-service-1", status: "success" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    fireEvent.click(screen.getByRole("button", { name: "Send Test Request" }));
+    await waitFor(() => {
+      expect(screen.getAllByText("orders-service-1").length).toBeGreaterThan(0);
+    });
+    const row = screen.getAllByText("orders-service-1").find((el) => el.tagName === "TD");
+    fireEvent.click(row);
+    expect(screen.queryByLabelText("Request trace timeline")).not.toBeInTheDocument();
+  });
+
   it("dismisses the alert banner when Dismiss is clicked", async () => {
     localStorage.clear();
     let callIdx = 0;

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -273,6 +273,55 @@ describe("Dashboard", () => {
     expect(screen.getByText(/Error rate above 10%/i)).toBeInTheDocument();
   });
 
+  it("renders the Services Status panel with breaker badges from /api/v1/services", async () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/services")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({
+            orders: {
+              requests: 5,
+              instances: [
+                { name: "orders-service-1", url: "http://localhost:9001", healthy: true, activeRequests: 0, requests: 3, failures: 1, breaker: "closed" },
+                { name: "orders-service-2", url: "http://localhost:9002", healthy: false, activeRequests: 0, requests: 2, failures: 5, breaker: "open" },
+              ],
+            },
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("breaker-orders-service-1")).toHaveTextContent("closed");
+      expect(screen.getByTestId("breaker-orders-service-2")).toHaveTextContent("open");
+    });
+    expect(screen.getByLabelText("orders instances")).toBeInTheDocument();
+  });
+
+  it("shows '—' breaker badge when backend has not yet returned breaker state", async () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/services")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({
+            orders: {
+              requests: 0,
+              instances: [{ name: "orders-service-1", url: "http://localhost:9001", healthy: true }],
+            },
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("breaker-orders-service-1")).toHaveTextContent("—");
+    });
+  });
+
   it("renders the trace timeline in the request detail modal when trace is present", async () => {
     localStorage.clear();
     vi.spyOn(global, "fetch").mockImplementation((url) => {

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -200,4 +200,29 @@ describe("Dashboard", () => {
     expect(screen.getAllByText("Settings").length).toBeGreaterThan(0);
     expect(screen.getByText("Show Settings")).toBeInTheDocument();
   });
+
+  it("applies a theme attribute on documentElement on mount", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true, status: 200, json: async () => ({ status: "ok" }),
+    });
+    document.documentElement.removeAttribute("data-theme");
+    render(<Dashboard />);
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute("data-theme")).toMatch(/light|dark/);
+    });
+  });
+
+  it("flips data-theme to dark when the theme select is set to Dark", async () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true, status: 200, json: async () => ({ status: "ok" }),
+    });
+    render(<Dashboard />);
+    fireEvent.click(screen.getByText("Show Settings"));
+    const themeSelect = screen.getByLabelText("Theme");
+    fireEvent.change(themeSelect, { target: { value: "dark" } });
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    });
+  });
 });

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -225,4 +225,79 @@ describe("Dashboard", () => {
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     });
   });
+
+  it("renders enable-alerts checkbox and threshold input in settings", () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true, status: 200, json: async () => ({ status: "ok" }),
+    });
+    render(<Dashboard />);
+    fireEvent.click(screen.getByText("Show Settings"));
+    expect(screen.getByLabelText("Enable error rate alerts")).toBeInTheDocument();
+    expect(screen.getByLabelText("Error rate alert threshold")).toBeInTheDocument();
+  });
+
+  it("does not render the alert banner when there are no errors", () => {
+    localStorage.clear();
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true, status: 200, json: async () => ({ status: "ok" }),
+    });
+    render(<Dashboard />);
+    expect(screen.queryByRole("alert", { name: "Error rate alert" })).not.toBeInTheDocument();
+  });
+
+  it("shows the alert banner when error rate crosses the threshold", async () => {
+    localStorage.clear();
+    let callIdx = 0;
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/request")) {
+        callIdx++;
+        return Promise.resolve({
+          ok: false, status: 500,
+          json: async () => ({ requestId: `req-${callIdx}`, routedTo: "orders-1" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    const sendBtn = screen.getByRole("button", { name: "Send Test Request" });
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(sendBtn);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Send Test Request" })).not.toBeDisabled();
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByRole("alert", { name: "Error rate alert" })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Error rate above 10%/i)).toBeInTheDocument();
+  });
+
+  it("dismisses the alert banner when Dismiss is clicked", async () => {
+    localStorage.clear();
+    let callIdx = 0;
+    vi.spyOn(global, "fetch").mockImplementation((url) => {
+      if (url.includes("/api/v1/request")) {
+        callIdx++;
+        return Promise.resolve({
+          ok: false, status: 500,
+          json: async () => ({ requestId: `req-${callIdx}`, routedTo: "orders-1" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ status: "ok" }) });
+    });
+    render(<Dashboard />);
+    const sendBtn = screen.getByRole("button", { name: "Send Test Request" });
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(sendBtn);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Send Test Request" })).not.toBeDisabled();
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByRole("alert", { name: "Error rate alert" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText("Dismiss alert"));
+    expect(screen.queryByRole("alert", { name: "Error rate alert" })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -212,6 +212,30 @@ export function computeServiceErrorRates(requestLog, windowSize = 20) {
   }));
 }
 
+export function parseTrace(entry) {
+  const trace = entry?.response?.trace ?? entry?.trace;
+  if (!Array.isArray(trace) || trace.length === 0) return [];
+
+  return trace.map((step, i) => {
+    const attempt = Number(step?.attempt);
+    const latencyMs = Number(step?.latencyMs);
+    const rawStatus = (step?.status ?? "").toString().toLowerCase();
+    const outcome =
+      rawStatus === "success" || rawStatus === "ok"
+        ? "success"
+        : rawStatus === "fail" || rawStatus === "error" || rawStatus === "failure"
+          ? "fail"
+          : rawStatus || "unknown";
+    return {
+      attempt: Number.isFinite(attempt) && attempt > 0 ? attempt : i + 1,
+      instance: step?.instance || "—",
+      outcome,
+      latencyMs: Number.isFinite(latencyMs) ? latencyMs : null,
+      error: step?.error || null,
+    };
+  });
+}
+
 export function findAlertingServices(requestLog, settings) {
   if (!settings?.enableAlerts) return [];
   const threshold = Number(settings?.errorRateAlertPct);

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -140,10 +140,12 @@ export function toCsv(requestLog) {
 }
 
 const SETTINGS_KEY = "edgeforge:settings";
+const VALID_THEMES = ["system", "light", "dark"];
 const DEFAULT_SETTINGS = {
   pollInterval: 1500,
   maxLogSize: 100,
   chartWindow: 30,
+  theme: "system",
 };
 
 export function loadSettings() {
@@ -151,7 +153,9 @@ export function loadSettings() {
     const raw = typeof localStorage !== "undefined" && localStorage.getItem(SETTINGS_KEY);
     if (!raw) return { ...DEFAULT_SETTINGS };
     const parsed = JSON.parse(raw);
-    return { ...DEFAULT_SETTINGS, ...parsed };
+    const merged = { ...DEFAULT_SETTINGS, ...parsed };
+    if (!VALID_THEMES.includes(merged.theme)) merged.theme = "system";
+    return merged;
   } catch {
     return { ...DEFAULT_SETTINGS };
   }
@@ -165,6 +169,20 @@ export function saveSettings(settings) {
   } catch {
     /* ignore */
   }
+}
+
+export function resolveTheme(theme) {
+  if (theme === "light" || theme === "dark") return theme;
+  if (typeof window !== "undefined" && window.matchMedia) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return "light";
+}
+
+export function applyTheme(theme) {
+  if (typeof document === "undefined") return;
+  const resolved = resolveTheme(theme);
+  document.documentElement.setAttribute("data-theme", resolved);
 }
 
 export function formatMetricsEntry(reqs, errs, rl, prevReqs, prevErrs, prevRl) {

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -146,6 +146,9 @@ const DEFAULT_SETTINGS = {
   maxLogSize: 100,
   chartWindow: 30,
   theme: "system",
+  enableAlerts: true,
+  errorRateAlertPct: 10,
+  alertWindowSize: 20,
 };
 
 export function loadSettings() {
@@ -183,6 +186,41 @@ export function applyTheme(theme) {
   if (typeof document === "undefined") return;
   const resolved = resolveTheme(theme);
   document.documentElement.setAttribute("data-theme", resolved);
+}
+
+export function computeServiceErrorRates(requestLog, windowSize = 20) {
+  if (!Array.isArray(requestLog) || requestLog.length === 0) return [];
+
+  const slice = requestLog.slice(0, Math.max(1, windowSize));
+  const byService = {};
+  for (const entry of slice) {
+    const service = entry?.routedTo;
+    if (!service || service === "—") continue;
+    if (!byService[service]) byService[service] = { service, total: 0, errors: 0 };
+    const code = Number(entry?.status);
+    byService[service].total += 1;
+    if ((Number.isFinite(code) && code >= 400 && code !== 429) || entry?.status === "error") {
+      byService[service].errors += 1;
+    }
+  }
+
+  return Object.values(byService).map((b) => ({
+    service: b.service,
+    total: b.total,
+    errors: b.errors,
+    errorRatePct: b.total > 0 ? Math.round((b.errors / b.total) * 1000) / 10 : 0,
+  }));
+}
+
+export function findAlertingServices(requestLog, settings) {
+  if (!settings?.enableAlerts) return [];
+  const threshold = Number(settings?.errorRateAlertPct);
+  if (!Number.isFinite(threshold) || threshold <= 0) return [];
+  const windowSize = Number(settings?.alertWindowSize) || 20;
+
+  return computeServiceErrorRates(requestLog, windowSize)
+    .filter((row) => row.total >= 3 && row.errorRatePct >= threshold)
+    .sort((a, b) => b.errorRatePct - a.errorRatePct);
 }
 
 export function formatMetricsEntry(reqs, errs, rl, prevReqs, prevErrs, prevRl) {

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -212,6 +212,51 @@ export function computeServiceErrorRates(requestLog, windowSize = 20) {
   }));
 }
 
+export function parseServices(data) {
+  if (!data || typeof data !== "object") return [];
+
+  return Object.entries(data).map(([service, raw]) => {
+    const instances = Array.isArray(raw?.instances) ? raw.instances : [];
+    return {
+      service,
+      requests: Number.isFinite(Number(raw?.requests)) ? Number(raw.requests) : 0,
+      instances: instances.map((inst) => ({
+        name: inst?.name || "—",
+        url: inst?.url || "",
+        healthy: inst?.healthy !== false,
+        activeRequests: Number.isFinite(Number(inst?.activeRequests))
+          ? Number(inst.activeRequests)
+          : 0,
+        requests: Number.isFinite(Number(inst?.requests)) ? Number(inst.requests) : 0,
+        failures: Number.isFinite(Number(inst?.failures)) ? Number(inst.failures) : 0,
+        breaker: normalizeBreakerState(inst?.breaker),
+      })),
+    };
+  });
+}
+
+export function normalizeBreakerState(state) {
+  const s = (state ?? "").toString().toLowerCase().trim();
+  if (s === "open") return "open";
+  if (s === "half-open" || s === "halfopen" || s === "half_open") return "half-open";
+  if (s === "closed") return "closed";
+  return "unknown";
+}
+
+export function breakerBadge(state) {
+  const normalized = normalizeBreakerState(state);
+  switch (normalized) {
+    case "open":
+      return { label: "open", bg: "#fef2f2", color: "#b91c1c", border: "#fecaca" };
+    case "half-open":
+      return { label: "half-open", bg: "#fffbeb", color: "#92400e", border: "#fde68a" };
+    case "closed":
+      return { label: "closed", bg: "#ecfdf5", color: "#065f46", border: "#a7f3d0" };
+    default:
+      return { label: "—", bg: "var(--bg-muted)", color: "var(--text-secondary)", border: "var(--border)" };
+  }
+}
+
 export function parseTrace(entry) {
   const trace = entry?.response?.trace ?? entry?.trace;
   if (!Array.isArray(trace) || trace.length === 0) return [];

--- a/frontend/src/utils/metrics.test.js
+++ b/frontend/src/utils/metrics.test.js
@@ -14,6 +14,7 @@ import {
   applyTheme,
   computeServiceErrorRates,
   findAlertingServices,
+  parseTrace,
 } from "./metrics";
 
 describe("computeRate", () => {
@@ -485,4 +486,78 @@ describe("findAlertingServices", () => {
     });
     expect(result.map((r) => r.service)).toEqual(["b", "a"]);
   });
+});
+
+describe("parseTrace", () => {
+  it("returns empty array when there is no trace", () => {
+    expect(parseTrace(null)).toEqual([]);
+    expect(parseTrace({})).toEqual([]);
+    expect(parseTrace({ response: {} })).toEqual([]);
+    expect(parseTrace({ response: { trace: null } })).toEqual([]);
+    expect(parseTrace({ response: { trace: [] } })).toEqual([]);
+  });
+
+  it("normalizes a single-attempt success trace", () => {
+    const entry = {
+      response: {
+        trace: [
+          { attempt: 1, instance: "orders-service-1", status: "success", latencyMs: 35 },
+        ],
+      },
+    };
+    expect(parseTrace(entry)).toEqual([
+      { attempt: 1, instance: "orders-service-1", outcome: "success", latencyMs: 35, error: null },
+    ]);
+  });
+
+  it("normalizes a retry trace with a failed first attempt", () => {
+    const entry = {
+      response: {
+        trace: [
+          { attempt: 1, instance: "orders-service-1", status: "fail", latencyMs: 120, error: "connection refused" },
+          { attempt: 2, instance: "orders-service-2", status: "success", latencyMs: 30 },
+        ],
+      },
+    };
+    const result = parseTrace(entry);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ attempt: 1, outcome: "fail", error: "connection refused" });
+    expect(result[1]).toMatchObject({ attempt: 2, outcome: "success", error: null });
+  });
+
+  it("backfills missing attempt numbers and latency", () => {
+    const entry = {
+      response: {
+        trace: [
+          { instance: "a", status: "success" },
+          { instance: "b", status: "fail", latencyMs: "bad" },
+        ],
+      },
+    };
+    const result = parseTrace(entry);
+    expect(result[0].attempt).toBe(1);
+    expect(result[1].attempt).toBe(2);
+    expect(result[0].latencyMs).toBe(null);
+    expect(result[1].latencyMs).toBe(null);
+  });
+
+  it("normalizes alternate status keywords (ok/error)", () => {
+    const entry = {
+      response: {
+        trace: [
+          { attempt: 1, instance: "a", status: "ok" },
+          { attempt: 2, instance: "b", status: "ERROR" },
+        ],
+      },
+    };
+    const result = parseTrace(entry);
+    expect(result[0].outcome).toBe("success");
+    expect(result[1].outcome).toBe("fail");
+  });
+
+  it("accepts a trace at the top level (not nested under response)", () => {
+    const entry = { trace: [{ attempt: 1, instance: "a", status: "success" }] };
+    expect(parseTrace(entry)).toHaveLength(1);
+  });
+
 });

--- a/frontend/src/utils/metrics.test.js
+++ b/frontend/src/utils/metrics.test.js
@@ -10,6 +10,8 @@ import {
   toCsv,
   loadSettings,
   saveSettings,
+  resolveTheme,
+  applyTheme,
 } from "./metrics";
 
 describe("computeRate", () => {
@@ -293,14 +295,21 @@ describe("loadSettings / saveSettings", () => {
     expect(s.pollInterval).toBe(1500);
     expect(s.maxLogSize).toBe(100);
     expect(s.chartWindow).toBe(30);
+    expect(s.theme).toBe("system");
   });
 
-  it("round-trips saved settings", () => {
-    saveSettings({ pollInterval: 3000, maxLogSize: 200, chartWindow: 60 });
+  it("round-trips saved settings including theme", () => {
+    saveSettings({ pollInterval: 3000, maxLogSize: 200, chartWindow: 60, theme: "dark" });
     const s = loadSettings();
     expect(s.pollInterval).toBe(3000);
     expect(s.maxLogSize).toBe(200);
     expect(s.chartWindow).toBe(60);
+    expect(s.theme).toBe("dark");
+  });
+
+  it("coerces unknown theme value back to system", () => {
+    saveSettings({ pollInterval: 1500, maxLogSize: 100, chartWindow: 30, theme: "neon" });
+    expect(loadSettings().theme).toBe("system");
   });
 
   it("falls back to defaults when localStorage has invalid JSON", () => {
@@ -309,5 +318,35 @@ describe("loadSettings / saveSettings", () => {
     expect(s.pollInterval).toBe(1500);
     expect(s.maxLogSize).toBe(100);
     expect(s.chartWindow).toBe(30);
+    expect(s.theme).toBe("system");
+  });
+});
+
+describe("resolveTheme / applyTheme", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("resolveTheme returns explicit theme when light or dark", () => {
+    expect(resolveTheme("light")).toBe("light");
+    expect(resolveTheme("dark")).toBe("dark");
+  });
+
+  it("resolveTheme follows prefers-color-scheme when system", () => {
+    const original = window.matchMedia;
+    window.matchMedia = (q) => ({
+      matches: q.includes("dark"),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    });
+    expect(resolveTheme("system")).toBe("dark");
+    window.matchMedia = original;
+  });
+
+  it("applyTheme writes data-theme on documentElement", () => {
+    applyTheme("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    applyTheme("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 });

--- a/frontend/src/utils/metrics.test.js
+++ b/frontend/src/utils/metrics.test.js
@@ -15,6 +15,9 @@ import {
   computeServiceErrorRates,
   findAlertingServices,
   parseTrace,
+  parseServices,
+  normalizeBreakerState,
+  breakerBadge,
 } from "./metrics";
 
 describe("computeRate", () => {
@@ -559,5 +562,96 @@ describe("parseTrace", () => {
     const entry = { trace: [{ attempt: 1, instance: "a", status: "success" }] };
     expect(parseTrace(entry)).toHaveLength(1);
   });
+});
 
+describe("parseServices", () => {
+  it("returns empty array for null/non-object input", () => {
+    expect(parseServices(null)).toEqual([]);
+    expect(parseServices(undefined)).toEqual([]);
+    expect(parseServices("nope")).toEqual([]);
+  });
+
+  it("normalizes a multi-service registry response", () => {
+    const data = {
+      orders: {
+        requests: 5,
+        instances: [
+          {
+            name: "orders-service-1",
+            url: "http://localhost:9001",
+            healthy: true,
+            activeRequests: 0,
+            requests: 3,
+            failures: 1,
+            breaker: "closed",
+          },
+          {
+            name: "orders-service-2",
+            url: "http://localhost:9002",
+            healthy: false,
+            activeRequests: 0,
+            requests: 2,
+            failures: 5,
+            breaker: "open",
+          },
+        ],
+      },
+    };
+    const result = parseServices(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].service).toBe("orders");
+    expect(result[0].requests).toBe(5);
+    expect(result[0].instances).toHaveLength(2);
+    expect(result[0].instances[0].breaker).toBe("closed");
+    expect(result[0].instances[1].breaker).toBe("open");
+    expect(result[0].instances[1].healthy).toBe(false);
+  });
+
+  it("falls back to safe defaults for missing fields", () => {
+    const data = { analytics: { instances: [{ name: "analytics-1" }] } };
+    const result = parseServices(data);
+    const inst = result[0].instances[0];
+    expect(inst.healthy).toBe(true);
+    expect(inst.activeRequests).toBe(0);
+    expect(inst.requests).toBe(0);
+    expect(inst.failures).toBe(0);
+    expect(inst.breaker).toBe("unknown");
+  });
+
+  it("handles a service with no instances", () => {
+    const data = { orders: { requests: 0 } };
+    expect(parseServices(data)[0]).toEqual({
+      service: "orders",
+      requests: 0,
+      instances: [],
+    });
+  });
+});
+
+describe("normalizeBreakerState / breakerBadge", () => {
+  it("normalizes known states", () => {
+    expect(normalizeBreakerState("OPEN")).toBe("open");
+    expect(normalizeBreakerState("Half-Open")).toBe("half-open");
+    expect(normalizeBreakerState("half_open")).toBe("half-open");
+    expect(normalizeBreakerState("closed")).toBe("closed");
+  });
+
+  it("returns 'unknown' for missing or invalid states", () => {
+    expect(normalizeBreakerState(undefined)).toBe("unknown");
+    expect(normalizeBreakerState("")).toBe("unknown");
+    expect(normalizeBreakerState("tripped")).toBe("unknown");
+  });
+
+  it("breakerBadge returns red palette for open, yellow for half-open, green for closed", () => {
+    expect(breakerBadge("open").label).toBe("open");
+    expect(breakerBadge("open").color).toBe("#b91c1c");
+    expect(breakerBadge("half-open").color).toBe("#92400e");
+    expect(breakerBadge("closed").color).toBe("#065f46");
+  });
+
+  it("breakerBadge falls back to neutral palette for unknown state", () => {
+    const badge = breakerBadge(undefined);
+    expect(badge.label).toBe("—");
+    expect(badge.color).toBe("var(--text-secondary)");
+  });
 });

--- a/frontend/src/utils/metrics.test.js
+++ b/frontend/src/utils/metrics.test.js
@@ -12,6 +12,8 @@ import {
   saveSettings,
   resolveTheme,
   applyTheme,
+  computeServiceErrorRates,
+  findAlertingServices,
 } from "./metrics";
 
 describe("computeRate", () => {
@@ -348,5 +350,139 @@ describe("resolveTheme / applyTheme", () => {
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     applyTheme("light");
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+});
+
+describe("computeServiceErrorRates", () => {
+  it("returns empty array for empty log", () => {
+    expect(computeServiceErrorRates([])).toEqual([]);
+    expect(computeServiceErrorRates(null)).toEqual([]);
+  });
+
+  it("computes per-service error rate", () => {
+    const log = [
+      { routedTo: "orders-1", status: 500 },
+      { routedTo: "orders-1", status: 200 },
+      { routedTo: "orders-1", status: 500 },
+      { routedTo: "orders-1", status: 200 },
+    ];
+    const result = computeServiceErrorRates(log);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      service: "orders-1",
+      total: 4,
+      errors: 2,
+      errorRatePct: 50,
+    });
+  });
+
+  it("excludes 429 from errors and 'unknown' (no routedTo) from results", () => {
+    const log = [
+      { routedTo: "orders-1", status: 429 },
+      { routedTo: "orders-1", status: 200 },
+      { status: 500 },
+      { routedTo: "—", status: 500 },
+    ];
+    const result = computeServiceErrorRates(log);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      service: "orders-1",
+      total: 2,
+      errors: 0,
+      errorRatePct: 0,
+    });
+  });
+
+  it("treats string 'error' status as a failure (network errors)", () => {
+    const log = [
+      { routedTo: "orders-1", status: "error" },
+      { routedTo: "orders-1", status: 200 },
+    ];
+    const result = computeServiceErrorRates(log);
+    expect(result[0].errors).toBe(1);
+    expect(result[0].errorRatePct).toBe(50);
+  });
+
+  it("respects windowSize and only looks at the most recent N entries (newest-first log)", () => {
+    const log = [
+      { routedTo: "orders-1", status: 500 },
+      { routedTo: "orders-1", status: 500 },
+      { routedTo: "orders-1", status: 200 },
+      { routedTo: "orders-1", status: 200 },
+      { routedTo: "orders-1", status: 200 },
+    ];
+    expect(computeServiceErrorRates(log, 2)[0]).toEqual({
+      service: "orders-1",
+      total: 2,
+      errors: 2,
+      errorRatePct: 100,
+    });
+  });
+});
+
+describe("findAlertingServices", () => {
+  const log = [
+    { routedTo: "orders-1", status: 500 },
+    { routedTo: "orders-1", status: 500 },
+    { routedTo: "orders-1", status: 500 },
+    { routedTo: "orders-1", status: 200 },
+    { routedTo: "analytics-1", status: 200 },
+    { routedTo: "analytics-1", status: 200 },
+    { routedTo: "analytics-1", status: 200 },
+  ];
+
+  it("returns empty list when alerts disabled", () => {
+    expect(findAlertingServices(log, { enableAlerts: false, errorRateAlertPct: 10 })).toEqual([]);
+  });
+
+  it("returns services exceeding the threshold", () => {
+    const result = findAlertingServices(log, {
+      enableAlerts: true,
+      errorRateAlertPct: 50,
+      alertWindowSize: 50,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].service).toBe("orders-1");
+    expect(result[0].errorRatePct).toBe(75);
+  });
+
+  it("returns empty list when no service crosses the threshold", () => {
+    const result = findAlertingServices(log, {
+      enableAlerts: true,
+      errorRateAlertPct: 90,
+      alertWindowSize: 50,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("ignores services with fewer than 3 requests in the window", () => {
+    const tinyLog = [
+      { routedTo: "orders-1", status: 500 },
+      { routedTo: "orders-1", status: 500 },
+    ];
+    expect(
+      findAlertingServices(tinyLog, {
+        enableAlerts: true,
+        errorRateAlertPct: 10,
+        alertWindowSize: 50,
+      })
+    ).toEqual([]);
+  });
+
+  it("sorts highest error rate first", () => {
+    const mixedLog = [
+      { routedTo: "a", status: 500 },
+      { routedTo: "a", status: 500 },
+      { routedTo: "a", status: 200 },
+      { routedTo: "b", status: 500 },
+      { routedTo: "b", status: 500 },
+      { routedTo: "b", status: 500 },
+    ];
+    const result = findAlertingServices(mixedLog, {
+      enableAlerts: true,
+      errorRateAlertPct: 10,
+      alertWindowSize: 50,
+    });
+    expect(result.map((r) => r.service)).toEqual(["b", "a"]);
   });
 });


### PR DESCRIPTION
Closes #F1

Adds a Services Status panel that polls /api/v1/services on the same interval as /api/v1/status. For each service it lists every instance with: healthy/unhealthy dot, instance name, circuit breaker state badge (closed/half-open/open with green/yellow/red palette; '—' fallback when backend has not yet returned a breaker field), active requests, failure count.

Replaces the prior one-shot 'knownInstances' fetch with a polled, parsed services list, so the request log filter dropdown also stays current as instances come and go.

Tests: 10 new vitest cases (83 -> 93 passing), 1 new Cypress E2E (asserts the panel renders an instance row).